### PR TITLE
Refactor Fabric utils into modules

### DIFF
--- a/fabric_utils/__init__.py
+++ b/fabric_utils/__init__.py
@@ -1,0 +1,13 @@
+from .api_utils import APIUtils
+from .file_utils import FileUtils
+from .spark_utils import SparkUtils
+from .sql_utils import SQLUtils
+from .layer import Layer
+
+__all__ = [
+    'APIUtils',
+    'FileUtils',
+    'SparkUtils',
+    'SQLUtils',
+    'Layer',
+]

--- a/fabric_utils/api_utils.py
+++ b/fabric_utils/api_utils.py
@@ -1,0 +1,63 @@
+import time
+import sys
+import json
+from datetime import datetime, timezone
+import os
+import requests
+import notebookutils
+from notebookutils import mssparkutils
+import logging
+
+class APIUtils:
+    @staticmethod
+    def api_request_with_stats(base_url: str, api: str, url_args: str):
+        """Make an API request and return timing statistics."""
+        start_time = time.time()
+        print(f"Making request to API endpoint: {base_url}{api}?{url_args} ")
+        response = requests.get(f"{base_url}{api}?{url_args}", headers=headers)
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        size = sys.getsizeof(json.dumps(response.json()))
+        start_time_dt = datetime.fromtimestamp(start_time, tz=timezone.utc)
+        end_time_dt = datetime.fromtimestamp(end_time, tz=timezone.utc)
+        url = f"{base_url}{api}?{url_args}"
+        return elapsed_time, response.json(), size, start_time_dt, end_time_dt, url
+
+    @staticmethod
+    def _create_api_folder(api: str) -> None:
+        if notebookutils.fs.exists(f"Files/Ingest/{api}"):
+            print(f"The file path: Files/Ingest/{api} already exists")
+            logger.info(f"The file path: Files/Ingest/{api} already exists")
+        else:
+            notebookutils.fs.mkdirs(f"Files/Ingest/{api}")
+            print(f"File created in Files/Ingest/{api}")
+            logger.info(f"File created in Files/Ingest{api}")
+
+    @staticmethod
+    def write_file(data: dict, api: str, symbol: str) -> str:
+        json_str = json.dumps(data)
+        directory_path = f"/lakehouse/default/Files/Ingest/{api}"
+        if not os.path.exists(directory_path):
+            os.makedirs(directory_path)
+            logger.info(f"Created directory: {directory_path}")
+        file_name = APIUtils._create_file_name(api, symbol)
+        file_path = os.path.join(directory_path, file_name)
+        with open(file_path, "w") as fw:
+            fw.write(json_str)
+            logger.info(f"{file_path} has been written")
+            print(f"{file_path} has been written")
+        return file_path
+
+    @staticmethod
+    def _create_file_name(api: str, symbol: str) -> str:
+        file_name_map = {
+            "stock/insider-transactions": symbol,
+            "stock/financials-reported": symbol,
+            "stock/insider-sentiment": symbol,
+        }
+        base_file_name = file_name_map.get(api)
+        print(f"Base File Path: {base_file_name}")
+        now_utc = datetime.utcnow()
+        formatted_date = now_utc.strftime("%m-%d-%Y")
+        file_name = f"{base_file_name}-{formatted_date}.json"
+        return file_name

--- a/fabric_utils/file_utils.py
+++ b/fabric_utils/file_utils.py
@@ -1,0 +1,50 @@
+import os
+import re
+from datetime import datetime
+import notebookutils
+from notebookutils import mssparkutils
+from notebookutils.mssparkutils.fs import ls
+
+class FileUtils:
+    @staticmethod
+    def get_workspace_id(file_path: str):
+        pattern = r"abfss://([^@]+)@"
+        match = re.search(pattern, file_path)
+        return match.group(1) if match else None
+
+    @staticmethod
+    def get_lakehouse_id(file_path: str):
+        string_list = file_path.split("/")
+        return string_list[3]
+
+    @staticmethod
+    def find_all_directories_with_files(start_dir: str) -> list:
+        directories_with_files = set()
+
+        def traverse_directory(directory):
+            items = ls(directory)
+            contains_file = False
+            for item in items:
+                if item.isDir:
+                    traverse_directory(item.path)
+                else:
+                    contains_file = True
+            if contains_file:
+                directories_with_files.add(directory)
+
+        traverse_directory(start_dir)
+        return list(directories_with_files)
+
+    @staticmethod
+    def split_path_return_last(file_path: str) -> str:
+        my_file_list = file_path.split("/")
+        target_folder = my_file_list[-1]
+        return target_folder
+
+    @staticmethod
+    def mount_lakehouse(source_path: str, mount_path: str):
+        try:
+            mssparkutils.fs.mount(source=source_path, mountPoint=mount_path)
+            print("Mount successful")
+        except Exception as e:
+            print(f"Mount failed: {e}")

--- a/fabric_utils/layer.py
+++ b/fabric_utils/layer.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+class Layer(Enum):
+    BRONZE = "bronze"
+    SILVER = "silver"
+    PLATINUM = "platinum"
+    GOLD = "gold"

--- a/fabric_utils/spark_utils.py
+++ b/fabric_utils/spark_utils.py
@@ -1,0 +1,84 @@
+from pyspark.sql import DataFrame, Row
+from pyspark.sql.functions import current_timestamp, lit, concat_ws, sha2, struct, col, when, to_timestamp
+from pyspark.errors import SparkUpgradeException
+from notebookutils import mssparkutils
+from fabric_utils.file_utils import FileUtils
+from fabric_utils.layer import Layer
+from datetime import datetime
+
+class SparkUtils:
+    @staticmethod
+    def load_data(file_path, file_format, options=None):
+        if options is None:
+            options = {}
+        format_to_method = {
+            'json': spark.read.options(**options).json,
+            'csv': spark.read.options(**options).csv,
+        }
+        read_method = format_to_method.get(file_format.lower())
+        if read_method is None:
+            raise ValueError(f'Unsupported file format: {file_format}')
+        df = read_method(file_path)
+        return df
+
+    @staticmethod
+    def add_hash_column(df: DataFrame, hash_col_name: str = "hash") -> DataFrame:
+        struct_cols = struct(*df.columns)
+        hashed_col = sha2(struct_cols.cast("string"), 256)
+        df_with_hash = df.withColumn(hash_col_name, hashed_col)
+        return df_with_hash
+
+    @staticmethod
+    def write_bronze_tables(df: DataFrame, full_target_path: str, ingest_path: str, processed_path: str, failed_path: str):
+        try:
+            df.write.format('delta').mode('append').option("mergeSchema", "true").save(full_target_path)
+            files = mssparkutils.fs.ls(ingest_path)
+            for file_info in files:
+                file_name = file_info.name
+                print(f'{file_name}\n\n')
+                full_file_name = f'{ingest_path}/{file_name}'
+                SparkUtils._mv_processed_files(full_file_name, ingest_path, processed_path, failed_path, handling='processed')
+        except SparkUpgradeException:
+            SparkUtils._handle_ancient_dates_sentinel(df, full_target_path, '')
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            for file_info in files:
+                file_name = file_info.name
+                full_file_name = f'{ingest_path}/{file_name}'
+                SparkUtils._mv_processed_files(full_file_name, ingest_path, processed_path, failed_path, handling='failed')
+
+    @staticmethod
+    def _mv_processed_files(full_file_name: str, ingest_path: str, processed_path: str, failed_path: str, handling: str):
+        my_file = FileUtils.split_path_return_last(full_file_name)
+        if handling == 'processed':
+            full_target_path = f'{processed_path}/{my_file}'
+            print(f'INFO: Process Success: Moving file: {full_file_name} from {ingest_path} to {full_target_path}')
+        elif handling == 'failed':
+            full_target_path = f'{failed_path}/{my_file}'
+            print(f'ERROR: Process Failed: Moving file: {full_file_name} from {ingest_path} to {full_target_path}')
+        mssparkutils.fs.mv(full_file_name, f'{processed_path}/{my_file}')
+
+    @staticmethod
+    def lookup_folder_source_target_mapping(folder_name: str, layer: Layer = Layer.BRONZE):
+        metadata_lh_df = spark.read.format("delta").load('abfss://c0a7b8a9-eb12-495a-b863-2cb583e31154@onelake.dfs.fabric.microsoft.com/1ac4412c-84bb-4fe9-8629-68d6faf28eaf/Tables/folder_source_target_mapping')
+        print(f'Layer Value: {layer.value}')
+        result = metadata_lh_df.filter((col('folder') == folder_name) & (col('layer') == layer.value)).select('table', 'source_file_path', 'full_target_path', 'processed_file_path', 'failed_file_path').first()
+        table_name = result['table']
+        source_file_path = result['source_file_path']
+        full_target_path = result['full_target_path']
+        processed_file_path = result['processed_file_path']
+        failed_file_path = result['failed_file_path']
+        print(f"Table: {table_name}")
+        print(f"Source File Path: {source_file_path}")
+        print(f"Full Target Path: {full_target_path}")
+        print(f"Processed File Path: {processed_file_path}")
+        print(f"Failed File Path: {failed_file_path}")
+        return table_name, source_file_path, full_target_path, processed_file_path, failed_file_path
+
+    @staticmethod
+    def _handle_ancient_dates_sentinel(df: DataFrame, full_target_path: str, date_col: str):
+        df_clean = df.withColumn(
+            date_col,
+            when(col(date_col) < lit('1900-01-01'), lit('1900-01-01 00:00:00')).otherwise(col(date_col))
+        )
+        return df_clean

--- a/fabric_utils/sql_utils.py
+++ b/fabric_utils/sql_utils.py
@@ -1,0 +1,69 @@
+from datetime import datetime, timezone
+import pyodbc
+
+class SQLUtils:
+    @staticmethod
+    def connect_sql_database(server_name: str, database_name: str, username: str, password: str):
+        driver = '{ODBC Driver 18 for SQL Server}'
+        conn_str = f'DRIVER={driver};SERVER={server_name};DATABASE={database_name};UID={username};PWD={password}'
+        conn = pyodbc.connect(conn_str)
+        cursor = conn.cursor()
+        return conn
+
+    @staticmethod
+    def insert_schema_registry(cxn, tableName: str, layer: str, fullTablePath: str, namespace: str, schemaDefinition: str, tableLakehouse: str, tableSource: str, tableLakehouseID: str, tableWorkspaceID: str, createdByPipelineName: str, createdByPipelineRunID: str):
+        cursor = cxn.cursor()
+        lastModifieddttm = datetime.now(timezone.utc)
+        insert_query = """
+        INSERT INTO schemaRegistry (tableName, layer, fullTablePath, namespace, schemaDefinition, tableLakehouse, tableSource, tableLakehouseID, tableWorkspaceID, _createdByPipelineName, _createdByPipelineRunID, _lastModifieddttm)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+        schemaDefinition = _prepare_schema_for_insert(schemaDefinition)
+        values = (tableName, layer, fullTablePath, namespace, schemaDefinition, tableLakehouse, tableSource, tableLakehouseID, tableWorkspaceID, createdByPipelineName, createdByPipelineRunID, lastModifieddttm)
+        cursor.execute(insert_query, values)
+        cxn.commit()
+        cursor.close()
+        cxn.close()
+
+    @staticmethod
+    def check_schema_exists(cxn, check_schema: str):
+        str_schema_check = _prepare_schema_for_insert(check_schema)
+        cursor = cxn.cursor()
+        select_query = f"""
+        SELECT * FROM schemaRegistry WHERE schemaDefinition = '{str_schema_check}'
+        """
+        print(f'Running Query: {select_query}')
+        results = cursor.execute(select_query)
+        resultsall_results = results.fetchall()
+        if len(resultsall_results) == 0:
+            return False
+        else:
+            return True
+
+    @staticmethod
+    def get_existing_schema_results(cxn):
+        cursor = cxn.cursor()
+        select_query = """
+        SELECT * FROM schemaRegistry
+        """
+        results = cursor.execute(select_query)
+        resultsall_results = results.fetchall()
+        first_row_results = resultsall_results[0]
+        id = first_row_results[0]
+        name = first_row_results[1]
+        layer = first_row_results[2]
+        namespace = first_row_results[3]
+        schemaDefinition = first_row_results[4]
+        return id, name, layer, namespace, schemaDefinition
+
+    @staticmethod
+    def _prepare_schema_for_insert(schema):
+        schema_str = str(schema)
+        schema_str = schema_str.replace("'", '"')
+        return schema_str
+
+    @staticmethod
+    def convert_schema_to_pyspark(strSchema: str):
+        schema_str = strSchema.replace('"', "'")
+        return schema_str
+


### PR DESCRIPTION
## Summary
- extract code from the `fabric_utils` notebook into standalone modules
- add helper classes for API, SQL, Spark and file utilities
- expose helpers via a package-level `__init__`

## Testing
- `python -m py_compile fabric_utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68328abad5988329af57f46c433af662